### PR TITLE
Catch panic at FFI boundary.

### DIFF
--- a/src/cbox.h
+++ b/src/cbox.h
@@ -77,7 +77,11 @@ typedef enum {
 
     // An attempt was made to initialise a new session with a prekey ID
     // for which no prekey could be found.
-    CBOX_PREKEY_NOT_FOUND        = 14
+    CBOX_PREKEY_NOT_FOUND        = 14,
+
+    // An unknown critical error was encountered which prevented the
+    // computation from succeeding.
+    CBOX_PANIC                   = 15
 } CBoxResult;
 
 // CBoxIdentityMode /////////////////////////////////////////////////////////
@@ -285,7 +289,7 @@ void cbox_fingerprint_remote(CBoxSession const * s, CBoxVec ** fp);
 // `b` is the CBox that serves as the initialised context for obtaining
 // randomness.
 // `len` is the number of random bytes to generate.
-CBoxVec * cbox_random_bytes(CBox const * b, size_t len);
+CBoxResult cbox_random_bytes(CBox const * b, size_t len, CBoxVec ** rb);
 
 #ifdef __cplusplus
 }

--- a/test/main.c
+++ b/test/main.c
@@ -137,7 +137,9 @@ void test_prekey_removal(CBox * alice_box, CBox * bob_box) {
 
 void test_random_bytes(CBox const * b) {
     printf("test_random_bytes ... ");
-    CBoxVec * random = cbox_random_bytes(b, 16);
+    CBoxVec * random = NULL;
+    CBoxResult rc = cbox_random_bytes(b, 16, &random);
+    assert(rc == CBOX_SUCCESS);
     assert(16 == cbox_vec_len(random));
     cbox_vec_free(random);
     printf("OK\n");


### PR DESCRIPTION
Since unwinding from Rust into foreign code is undefined behaviour we
have stop panic at our FFI boundary. Until Rust RFCs 1236 or 1323 are
stabilised we have to utilise `std::thread::catch_panic` for this
purpose.