### PR TITLE
Dependency upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,13 @@ name = "cryptobox-c"
 version = "0.5.1"
 dependencies = [
  "cryptobox 0.5.1 (git+https://github.com/shared-secret/cryptobox?branch=develop)",
- "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proteus 0.4.1 (git+https://github.com/shared-secret/proteus?branch=develop)",
 ]
 
 [[package]]
 name = "byteorder"
-version = "0.3.13"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -17,16 +17,16 @@ name = "cbor-codec"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cryptobox"
 version = "0.5.1"
-source = "git+https://github.com/shared-secret/cryptobox?branch=develop#6d42fff141f6bb3c071b4fe2376a8db0302c291f"
+source = "git+https://github.com/shared-secret/cryptobox?branch=develop#0a06cec7cab1ad112e9ce7bd7abedce039f1d61d"
 dependencies = [
- "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbor-codec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proteus 0.4.1 (git+https://github.com/shared-secret/proteus?branch=develop)",
 ]
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -49,7 +49,7 @@ name = "libsodium-sys"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -63,10 +63,10 @@ name = "proteus"
 version = "0.4.1"
 source = "git+https://github.com/shared-secret/proteus?branch=develop#aaabc38cb446cb1c36d749557a13e27e7094cde9"
 dependencies = [
- "byteorder 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cbor-codec 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.1.0 (git+https://github.com/twittner/hkdf)",
- "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -80,7 +80,7 @@ name = "sodiumoxide"
 version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,19 @@ pub extern fn cbox_vec_len(v: &Vec<u8>) -> size_t {
 
 // Unsafe ///////////////////////////////////////////////////////////////////
 
+#[cfg(not(target_os = "android"))]
+fn to_str<'r>(s: *const c_char) -> Result<&'r str, str::Utf8Error> {
+    unsafe { CStr::from_ptr(s).to_str() }
+}
+
+#[cfg(target_os = "android")]
+#[cfg(any(target_arch = "arm", target_arch = "x86"))]
+fn to_str<'r>(s: *const c_char) -> Result<&'r str, str::Utf8Error> {
+    unsafe { CStr::from_ptr(s as *const i8).to_str() }
+}
+
+#[cfg(target_os = "android")]
+#[cfg(target_arch = "aarch64")]
 fn to_str<'r>(s: *const c_char) -> Result<&'r str, str::Utf8Error> {
     unsafe { CStr::from_ptr(s).to_str() }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -26,10 +26,21 @@ mod target {
         log(&format!("{}\0", e), LEVEL_ERROR)
     }
 
+    #[cfg(any(target_arch = "arm", target_arch = "x86"))]
     fn log(msg: &str, lvl: c_int) -> Result<()> {
         unsafe {
-            let tag = CStr::from_ptr(TAG.as_ptr() as *const c_char);
-            let msg = CStr::from_ptr(msg.as_ptr() as *const c_char);
+            let tag = CStr::from_ptr(TAG.as_ptr() as *const i8);
+            let msg = CStr::from_ptr(msg.as_ptr() as *const i8);
+            __android_log_write(lvl, tag.as_ptr() as *const u8, msg.as_ptr() as *const u8);
+        }
+        Ok(())
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn log(msg: &str, lvl: c_int) -> Result<()> {
+        unsafe {
+            let tag = CStr::from_ptr(TAG.as_ptr());
+            let msg = CStr::from_ptr(msg.as_ptr());
             __android_log_write(lvl, tag.as_ptr(), msg.as_ptr());
         }
         Ok(())


### PR DESCRIPTION
Upgrade to the latest `libc` and `byteorder`.

Note that the newer `libc` versions (`0.2+`) changed the default signedness of  `c_char` on 32 bit Android architectures from `i8` to `u8`. `std::ffi::CStr` still has signatures according to the older libc versions. Hence we need to do some temporary conversions between `i8` and `u8`. These should be safe because we don't make any assumptions about the signedness of `c_char` (and neither should any portable code).
